### PR TITLE
Yasir/task/new checker pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The following modifiers are available to customize the sticker effect:
 | `.stickerNoiseScale(_:)`       | 100.0         | Adjusts the scale of the noise pattern                        |
 | `.stickerNoiseIntensity(_:)`   | 1.2           | Controls the intensity of the noise effect                    |
 | `.stickerLightIntensity(_:)`   | 0.3           | Adjusts the intensity of the light reflection                 |
+| `.stickerPatternType(_:)`      | diamond       | Modifies the checker pattern                                  |     
 
 Example usage:
 

--- a/Sources/Sticker/Resources/Shaders/FoilShader.metal
+++ b/Sources/Sticker/Resources/Shaders/FoilShader.metal
@@ -82,7 +82,18 @@ half4 increaseContrast(half4 source, float pattern, float intensity) {
     return contrastedColor;
 }
 
-[[ stitchable ]] half4 foil(float2 position, half4 color, float2 offset, float2 size, float scale, float intensity, float contrast, float blendFactor, float checkerScale, float checkerIntensity, float noiseScale, float noiseIntensity) {
+float getPatternType(int option) {
+    switch (option) {
+        case 0:
+            return 45.0;
+        case 1:
+            return 0.0;
+        default:
+            return 45.0;  // Default as diamond for unspecified options
+    }
+}
+
+[[ stitchable ]] half4 foil(float2 position, half4 color, float2 offset, float2 size, float scale, float intensity, float contrast, float blendFactor, float checkerScale, float checkerIntensity, float noiseScale, float noiseIntensity, float patternType) {
     // Normalize the offset by dividing by size to keep it consistent across different view sizes
     float2 normalizedOffset = (offset + size * 250) / (size * scale) * 0.01;
 
@@ -91,7 +102,7 @@ half4 increaseContrast(half4 source, float pattern, float intensity) {
 
     // Scale the noise based on the normalized position and noiseScale parameter
     float gradientNoise = random(position) * 0.1;
-    float checker = checkerPattern(position / size * checkerScale, checkerScale, 45.0);
+    float checker = checkerPattern(position / size * checkerScale, checkerScale, getPatternType(patternType));
     float noise = noisePattern(position / size * noiseScale);
 
     // Calculate less saturated color shifts for a metallic effect

--- a/Sources/Sticker/Resources/Shaders/FoilShader.metal
+++ b/Sources/Sticker/Resources/Shaders/FoilShader.metal
@@ -126,7 +126,7 @@ float stickerPattern(int option, float2 uv, float scale) {
 
     // Scale the noise based on the normalized position and noiseScale parameter
     float gradientNoise = random(position) * 0.1;
-    float checker = stickerPattern(patternType, position / size * checkerScale, checkerScale);
+    float pattern = stickerPattern(patternType, position / size * checkerScale, checkerScale);
     float noise = noisePattern(position / size * noiseScale);
 
     // Calculate less saturated color shifts for a metallic effect
@@ -137,7 +137,7 @@ float stickerPattern(int option, float2 uv, float scale) {
     half4 foilColor = half4(r, g, b, 1.0);
     half4 mixedFoilColor = lightnessMix(color, foilColor, intensity, 0.3);
 
-    half4 checkerFoil = increaseContrast(mixedFoilColor, checker, checkerIntensity);
+    half4 checkerFoil = increaseContrast(mixedFoilColor, pattern, checkerIntensity);
     half4 noiseCheckerFoil = increaseContrast(checkerFoil, noise, noiseIntensity);
 
     return noiseCheckerFoil;

--- a/Sources/Sticker/StickerEffect/StickerEffect.swift
+++ b/Sources/Sticker/StickerEffect/StickerEffect.swift
@@ -20,7 +20,8 @@ private struct StickerEffectViewModifier: ViewModifier {
     @Environment(\.stickerNoiseScale) private var stickerNoiseScale
     @Environment(\.stickerNoiseIntensity) private var stickerNoiseIntensity
     @Environment(\.stickerLightIntensity) private var stickerLightIntensity
-
+    @Environment(\.stickerPattern) private var stickerPattern
+    
     func body(content: Content) -> some View {
         content
             .visualEffect { [motion, stickerLightIntensity] view, proxy in
@@ -41,7 +42,7 @@ private struct StickerEffectViewModifier: ViewModifier {
                 [
                     motion, stickerScale, stickerColorIntensity, stickerContrast, stickerBlend,
                     stickerCheckerScale, stickerCheckerIntensity, stickerNoiseScale,
-                    stickerNoiseIntensity
+                    stickerNoiseIntensity, stickerPattern
                 ] view, proxy in
                 view
                     .colorEffect(
@@ -56,7 +57,8 @@ private struct StickerEffectViewModifier: ViewModifier {
                             checkerScale: stickerCheckerScale,
                             checkerIntensity: stickerCheckerIntensity,
                             noiseScale: stickerNoiseScale,
-                            noiseIntensity: stickerNoiseIntensity
+                            noiseIntensity: stickerNoiseIntensity,
+                            patternType: stickerPattern
                         )
                     )
             }

--- a/Sources/Sticker/StickerEffectParameter/StickerEffectParameter.swift
+++ b/Sources/Sticker/StickerEffectParameter/StickerEffectParameter.swift
@@ -17,6 +17,7 @@ extension EnvironmentValues {
     @Entry var stickerNoiseScale: Float = 100
     @Entry var stickerNoiseIntensity: Float = 1.2
     @Entry var stickerLightIntensity: Float = 0.3
+    @Entry var stickerPattern: StickerPattern = .diamond
 }
 
 extension View {
@@ -54,5 +55,9 @@ extension View {
 
     public func stickerLightIntensity(_ intensity: Float) -> some View {
         environment(\.stickerLightIntensity, intensity)
+    }
+    
+    public func stickerPatternType(_ type: StickerPattern) -> some View {
+        environment(\.stickerPattern, type)
     }
 }

--- a/Sources/Sticker/Utils/Extensions/ShaderLibraryExtension.swift
+++ b/Sources/Sticker/Utils/Extensions/ShaderLibraryExtension.swift
@@ -34,7 +34,7 @@ extension ShaderLibrary {
             .float(checkerIntensity),
             .float(noiseScale),
             .float(noiseIntensity),
-            .float(patternType.uniqueIdentifier)
+            .float(Float(patternType.rawValue))
         )
     }
 
@@ -61,16 +61,7 @@ public extension ShaderLibrary {
     }
 }
 
-public enum StickerPattern: Sendable {
-    case diamond
-    case square
-    
-    var uniqueIdentifier: Float {
-        switch self {
-        case .diamond:
-            return 0.0
-        case .square:
-            return 1.0
-        }
-    }
+public enum StickerPattern: Int, Hashable, Equatable, Sendable {
+    case diamond = 0
+    case square = 1
 }

--- a/Sources/Sticker/Utils/Extensions/ShaderLibraryExtension.swift
+++ b/Sources/Sticker/Utils/Extensions/ShaderLibraryExtension.swift
@@ -20,7 +20,8 @@ extension ShaderLibrary {
         checkerScale: Float = 5,
         checkerIntensity: Float = 1.2,
         noiseScale: Float = 100,
-        noiseIntensity: Float = 1.2
+        noiseIntensity: Float = 1.2,
+        patternType: StickerPattern = .diamond
     ) -> Shader {
         moduleLibrary.foil(
             .float2(offset),
@@ -32,7 +33,8 @@ extension ShaderLibrary {
             .float(checkerScale),
             .float(checkerIntensity),
             .float(noiseScale),
-            .float(noiseIntensity)
+            .float(noiseIntensity),
+            .float(patternType.uniqueIdentifier)
         )
     }
 
@@ -56,5 +58,19 @@ public extension ShaderLibrary {
     static func compileStickerShaders() async throws {
         try await foilShader().compile(as: .colorEffect)
         try await reflectionShader().compile(as: .colorEffect)
+    }
+}
+
+public enum StickerPattern: Sendable {
+    case diamond
+    case square
+    
+    var uniqueIdentifier: Float {
+        switch self {
+        case .diamond:
+            return 0.0
+        case .square:
+            return 1.0
+        }
     }
 }


### PR DESCRIPTION
## Summary
I have introduced a modifier (`stickerPatternType(_:)`) that allows developers to set the pattern type to square, which is by default set to diamond.

Previously, the rotation degree was set to 45 degrees to give the pattern a diamond shape. I have now changed this value to 0 to make it square based on choice.

In the future, we can add more patterns, such as hexagon, circle, etc. To support this, I have created a switch-case structure in the Metal file and an enum in the Sticker module named `StickerPattern`.

### Example usage:

```
Image(systemName: "bolt.fill")
    .font(.system(size: 300))
    .stickerEffect()
    .stickerPatternType(.square)
```

### Updated Documentation
The README file has been updated to reflect these changes.

### That's it
Let me know what do you think about it. Thank you!