### PR TITLE
Lower deployment target to iOS 16 with availability gating

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Sticker",
     platforms: [
-        .iOS(.v17),
+        .iOS(.v16),
         .macOS(.v14),
         .visionOS(.v1)
     ],

--- a/Sources/Sticker/StickerEffect/StickerEffect.swift
+++ b/Sources/Sticker/StickerEffect/StickerEffect.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(iOS 17, *)
 private struct StickerEffectViewModifier: ViewModifier {
     @State private var motion: StickerMotion = .init()
 
@@ -73,7 +74,7 @@ private struct StickerEffectViewModifier: ViewModifier {
 extension View {
     @ViewBuilder
     public func stickerEffect(_ isEnabled: Bool = true) -> some View {
-        if isEnabled {
+        if isEnabled, #available(iOS 17, *) {
             modifier(StickerEffectViewModifier())
         } else {
             self
@@ -81,6 +82,7 @@ extension View {
     }
 }
 
+@available(iOS 17, *)
 #Preview {
     VStack {
         Circle()

--- a/Sources/Sticker/StickerMotionEffect/Effects/AccelerometerStickerMotionEffect.swift
+++ b/Sources/Sticker/StickerMotionEffect/Effects/AccelerometerStickerMotionEffect.swift
@@ -9,6 +9,7 @@
 import SwiftUI
 import CoreMotion
 
+@available(iOS 17, *)
 public struct AccelerometerStickerMotionEffect: StickerMotionEffect {
     let intensity: Double
     let maxRotation: Angle
@@ -45,6 +46,7 @@ public struct AccelerometerStickerMotionEffect: StickerMotionEffect {
     }
 }
 
+@available(iOS 17, *)
 public extension StickerMotionEffect where Self == AccelerometerStickerMotionEffect {
     static var accelerometer: Self {
         .accelerometer()

--- a/Sources/Sticker/StickerShaderUpdater/StickerShaderUpdater.swift
+++ b/Sources/Sticker/StickerShaderUpdater/StickerShaderUpdater.swift
@@ -6,9 +6,7 @@
 //
 
 import SwiftUI
-import Observation
 
-@Observable
 final class StickerShaderUpdater {
     typealias ChangeHandler = (_ motion: StickerMotion) -> Void
 

--- a/Sources/Sticker/Utils/Extensions/ShaderLibraryExtension.swift
+++ b/Sources/Sticker/Utils/Extensions/ShaderLibraryExtension.swift
@@ -7,6 +7,7 @@
 
 import SwiftUI
 
+@available(iOS 17, *)
 extension ShaderLibrary {
     static var moduleLibrary: ShaderLibrary { .bundle(.module) }
 
@@ -53,6 +54,7 @@ extension ShaderLibrary {
     }
 }
 
+@available(iOS 17, *)
 public extension ShaderLibrary {
     @available(iOS 18.0, macOS 15.0, visionOS 2.0, tvOS 18.0, watchOS 11.0, *)
     static func compileStickerShaders() async throws {


### PR DESCRIPTION
Drop the @Observable on StickerShaderUpdater (unobserved callback dispatcher) and gate the iOS 17 shader/accelerometer APIs behind @available(iOS 17, *) so the module imports into iOS 16 targets. stickerEffect() stays callable on iOS 16 as a no-op.